### PR TITLE
docs: update component pages for Demo Resource Standard v2

### DIFF
--- a/docs/01-overview.mdx
+++ b/docs/01-overview.mdx
@@ -34,9 +34,11 @@ Every component follows the same Terraform workflow:
 
 1. Clone the component repo
 2. `cd terraform/`
-3. Set required variables (each component documents its own)
+3. Copy `terraform.tfvars.example` to `terraform.tfvars` and set required variables (`subscription_id` is required for all; some components have additional required inputs)
 4. `terraform init && terraform plan && terraform apply`
 5. Verify via the component's health check endpoint
+
+Your deployer identifier is auto-resolved from your Azure AD account and embedded in all resource names (e.g., `rg-origin-server-lab-rmordasiewicz`).
 
 ## Cost Estimates
 

--- a/docs/cdn-simulator.mdx
+++ b/docs/cdn-simulator.mdx
@@ -31,12 +31,16 @@ TLS/Fingerprint, Bot Detection, Request Tracing, Edge Identity.
 
 ## Terraform Variables
 
-| Variable | Required | Default |
-|---|---|---|
-| `subscription_id` | Yes | — |
-| `origin_server` | Yes | — (origin URL with scheme) |
-| `origin_host` | Yes | — (host:port for NGINX upstream) |
-| `vm_size` | No | `Standard_F4s_v2` |
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `subscription_id` | Yes | — | Azure subscription ID |
+| `origin_server` | Yes | — | Origin URL with scheme |
+| `origin_host` | Yes | — | Origin host:port for NGINX upstream |
+| `deployer` | No | *(auto from Azure AD)* | Override for deployer identifier |
+| `location` | No | `eastus2` | Azure region |
+| `environment` | No | `lab` | Environment label for resource naming |
+| `vm_size` | No | `Standard_F4s_v2` | Azure VM size |
+| `disk_size_gb` | No | `30` | OS disk size in GB |
 
 ## Integration
 

--- a/docs/origin-server.mdx
+++ b/docs/origin-server.mdx
@@ -31,12 +31,14 @@ vulnerable web applications.
 
 ## Terraform Variables
 
-| Variable | Required | Default |
-|---|---|---|
-| `subscription_id` | Yes | — |
-| `resource_group_name` | No | `rg-origin-server` |
-| `location` | No | `eastus2` |
-| `vm_size` | No | `Standard_D16s_v3` |
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `subscription_id` | Yes | — | Azure subscription ID |
+| `deployer` | No | *(auto from Azure AD)* | Override for deployer identifier |
+| `location` | No | `eastus2` | Azure region |
+| `environment` | No | `lab` | Environment label for resource naming |
+| `vm_size` | No | `Standard_D16s_v3` | Azure VM size |
+| `disk_size_gb` | No | `60` | OS disk size in GB |
 
 ## Integration
 

--- a/docs/traffic-generator.mdx
+++ b/docs/traffic-generator.mdx
@@ -32,12 +32,17 @@ Pre-built scripts in `/opt/traffic-generator/suites/`:
 
 ## Terraform Variables
 
-| Variable | Required | Default |
-|---|---|---|
-| `subscription_id` | Yes | — |
-| `target_fqdn` | Yes | — (F5 XC load balancer FQDN) |
-| `target_origin_ip` | No | — (direct origin IP for bypass testing) |
-| `tool_tier` | No | `standard` (`standard` or `full`) |
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `subscription_id` | Yes | — | Azure subscription ID |
+| `target_fqdn` | Yes | — | F5 XC load balancer FQDN to target |
+| `deployer` | No | *(auto from Azure AD)* | Override for deployer identifier |
+| `location` | No | `eastus2` | Azure region |
+| `environment` | No | `lab` | Environment label for resource naming |
+| `vm_size` | No | `Standard_F16s_v2` | Azure VM size |
+| `disk_size_gb` | No | `64` | OS disk size in GB |
+| `target_origin_ip` | No | — | Direct origin IP for bypass testing |
+| `tool_tier` | No | `standard` | `standard` or `full` (includes Metasploit) |
 
 ## Integration
 


### PR DESCRIPTION
## Summary

- Update "Deployment Pattern" section in overview to reference `terraform.tfvars.example` and Azure AD deployer auto-resolution
- Update Terraform Variables tables in all three component pages to reflect standardized v2 variables
- Add `deployer`, `environment`, `disk_size_gb` to all variable tables
- Remove `resource_group_name` from origin-server (now auto-derived)
- Add Description column to all variable tables

Closes #4

## Test plan

- [x] All four MDX files have valid frontmatter
- [x] Variable tables match the standardized repos
- [ ] CI checks pass