### PR TITLE
fix: correct traffic generator suite count from 7 to 17 in marketplace card

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -22,7 +22,7 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:application-traffic-insight"
     title="Traffic Generator"
-    description="Azure VM with 50+ security testing tools and 7 pre-built attack suites."
+    description="Azure VM with 50+ security testing tools and 17 pre-built traffic suites."
     href="/demo-resources/traffic-generator/"
   />
   <LinkCard


### PR DESCRIPTION
## Summary

- Corrects the Traffic Generator LinkCard description in `docs/index.mdx` from "7 pre-built attack suites" to "17 pre-built traffic suites"
- Aligns the marketplace card with the actual count already documented in `traffic-generator.mdx` frontmatter
- Prevents stale data from propagating into `llms-full.txt` for AI assistant consumption

Closes #11

## Test plan

- [ ] CI checks pass
- [ ] Verify the LinkCard on the rendered index page shows "17 pre-built traffic suites"
- [ ] Confirm `llms-full.txt` regeneration picks up the corrected count