### PR TITLE
docs: apply DRY content thinning to marketplace documentation

### DIFF
--- a/docs/01-overview.mdx
+++ b/docs/01-overview.mdx
@@ -40,12 +40,22 @@ Every component follows the same Terraform workflow:
 
 Your deployer identifier is auto-resolved from your Azure AD account and embedded in all resource names (e.g., `rg-origin-server-lab-rmordasiewicz`).
 
-## Azure Resources
+## Cross-Component Integration
 
-| Component | VM Size |
-|---|---|
-| Origin Server | Standard_D16s_v3 (16 vCPU, 64 GiB) |
-| Traffic Generator | Standard_F16s_v2 (16 vCPU, compute) |
-| CDN Simulator | Standard_F4s_v2 (4 vCPU, compute) |
+Components combine to create complete demo environments:
+
+```
+Traffic Generator ──► F5 XC HTTP LB (WAF/Bot/API/CSD) ──► Origin Server
+                                     ▲
+                               CDN Simulator
+```
+
+**Deployment order:**
+
+1. **Origin server** — deploy first, it hosts the applications that all other components target
+2. **F5 XC HTTP load balancer** — configure an origin pool pointing to the origin server's public IP, then create an HTTP load balancer with WAF, Bot Defense, API Security, or Client-Side Defense policies
+3. **Traffic generator** and/or **CDN simulator** — deploy last, pointing at the F5 XC load balancer FQDN
+
+Each component's terraform variables reference the outputs of previously deployed components. See the component documentation for specific variable requirements.
 
 Use the [Azure pricing calculator](https://azure.microsoft.com/en-us/pricing/calculator/) for current cost estimates. Run `terraform destroy` when the lab is idle to stop charges.

--- a/docs/cdn-simulator.mdx
+++ b/docs/cdn-simulator.mdx
@@ -1,49 +1,19 @@
 ---
 title: CDN Simulator
-description: Azure Ubuntu 24.04 VM running NGINX as a CDN edge node simulator with 67+ vendor-specific headers, cache behavior simulation, and origin pull.
+description: Azure VM simulating CDN edge behavior with multi-vendor header injection for CDN integration demos.
 ---
 
-The CDN simulator is an Azure Ubuntu 24.04 VM (Standard_F4s_v2) running NGINX
-configured to behave like a CDN edge node, injecting vendor-specific headers and
-simulating cache behavior.
+The CDN simulator is an Azure VM running NGINX configured to behave like a CDN
+edge node. It injects realistic vendor-specific headers and simulates cache
+behavior for CDN integration demos with F5 Distributed Cloud.
 
-## Simulated CDN Features
+## Simulated Vendors
 
-- **Edge caching** with HIT/MISS/BYPASS/EXPIRED status reporting
-- **Origin pull** to upstream origin servers
-- **TLS termination** at the edge
-- **Cache-Control header** respect and enforcement
+- Akamai
+- Cloudflare
+- Amazon CloudFront
+- Fastly
+- Azure Front Door
 
-## Vendor Headers
-
-67+ request and response headers simulating behavior from:
-
-| Vendor | Header Examples |
-|---|---|
-| Akamai | `X-Akamai-Transformed`, `Akamai-Origin-Hop` |
-| Cloudflare | `CF-Ray`, `CF-IPCountry`, `CF-Connecting-IP` |
-| CloudFront | `X-Amz-Cf-Id`, `X-Amz-Cf-Pop` |
-| Fastly | `X-Served-By`, `X-Cache`, `X-Timer` |
-| Azure Front Door | `X-Azure-Ref`, `X-FD-HealthProbe` |
-
-Header categories include: Client IP, Geolocation, Device Detection,
-TLS/Fingerprint, Bot Detection, Request Tracing, Edge Identity.
-
-## Terraform Variables
-
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `subscription_id` | Yes | — | Azure subscription ID |
-| `origin_server` | Yes | — | Origin URL with scheme |
-| `origin_host` | Yes | — | Origin host:port for NGINX upstream |
-| `deployer` | No | *(auto from Azure AD)* | Override for deployer identifier |
-| `location` | No | `eastus2` | Azure region |
-| `environment` | No | `lab` | Environment label for resource naming |
-| `vm_size` | No | `Standard_F4s_v2` | Azure VM size |
-| `disk_size_gb` | No | `30` | OS disk size in GB |
-
-## Integration
-
-Deploy between clients and the origin server (or between clients and F5 XC).
-Point `origin_server` at either the origin VM's IP or the F5 XC VIP to test
-CDN-in-front-of-WAF scenarios.
+See the [CDN Simulator documentation](https://f5xc-salesdemos.github.io/cdn-simulator/)
+for nginx configuration, vendor headers, terraform variables, and deployment details.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -16,19 +16,19 @@ import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
   <LinkCard
     icon="f5xc:distributed-apps"
     title="Origin Server"
-    description="Ubuntu 24.04 VM with nginx reverse proxy to 41 Docker containers across 9 vulnerable web applications."
+    description="Azure VM hosting vulnerable web applications for WAF, API security, bot defense, and client-side defense testing."
     href="/demo-resources/origin-server/"
   />
   <LinkCard
     icon="f5xc:application-traffic-insight"
     title="Traffic Generator"
-    description="Azure VM with 50+ security testing tools and 17 pre-built traffic suites."
+    description="Azure VM generating attack traffic, reconnaissance, and bot simulation against F5 XC protected applications."
     href="/demo-resources/traffic-generator/"
   />
   <LinkCard
     icon="f5xc:content-delivery-network"
     title="CDN Simulator"
-    description="NGINX-based CDN edge node simulator with 67+ vendor-specific headers."
+    description="Azure VM simulating CDN edge behavior with multi-vendor header injection for CDN integration demos."
     href="/demo-resources/cdn-simulator/"
   />
 </CardGrid>

--- a/docs/origin-server.mdx
+++ b/docs/origin-server.mdx
@@ -1,46 +1,18 @@
 ---
 title: Origin Server
-description: Ubuntu 24.04 Azure VM running nginx reverse proxy to 41 Docker containers across 9 vulnerable web applications for WAF, API security, bot defense, and client-side defense testing.
+description: Azure VM hosting vulnerable web applications for WAF, API security, bot defense, and client-side defense testing.
 ---
 
-The origin server is an Ubuntu 24.04 Azure VM (Standard_D16s_v3) that runs an
-nginx reverse proxy distributing traffic to 41 Docker containers across 9
-vulnerable web applications.
+The origin server is an Azure VM that hosts vulnerable web applications behind
+an nginx reverse proxy. It provides targets for demonstrating F5 Distributed
+Cloud security features.
 
-## Applications
+## F5 XC Features Validated
 
-| Application | Path | Purpose |
-|---|---|---|
-| Juice Shop | `/juice-shop` | OWASP flagship, general web app attacks |
-| DVWA | `/dvwa` | WAF testing with configurable security levels |
-| VAmPI | `/vampi` | REST API vulnerabilities |
-| httpbin | `/httpbin` | HTTP request/response diagnostics |
-| whoami | `/whoami` | Request echo and header inspection |
-| CSD Demo | `/csd-demo` | Client-side defense JavaScript injection |
-| DVGA | `/dvga` | GraphQL API vulnerabilities |
-| RESTaurant | `/restaurant` | REST API with PostgreSQL backend |
-| crAPI | `:8888` | 7-microservice API security challenge |
+- **Web Application Firewall** — SQL injection, XSS, command injection, path traversal
+- **API Security** — REST and GraphQL API vulnerabilities, OWASP API Top 10
+- **Bot Defense** — credential stuffing targets, scraping endpoints
+- **Client-Side Defense** — JavaScript injection, Magecart-style attacks
 
-## Architecture
-
-- **nginx** reverse proxy with `reuseport`, sticky sessions, and proxy cache
-- **4 instances** per application for load balancing
-- **MariaDB 10.11** backend for DVWA
-- **PostgreSQL 15.4** backend for RESTaurant
-- **MongoDB + Mailhog** for crAPI microservices
-
-## Terraform Variables
-
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `subscription_id` | Yes | — | Azure subscription ID |
-| `deployer` | No | *(auto from Azure AD)* | Override for deployer identifier |
-| `location` | No | `eastus2` | Azure region |
-| `environment` | No | `lab` | Environment label for resource naming |
-| `vm_size` | No | `Standard_D16s_v3` | Azure VM size |
-| `disk_size_gb` | No | `60` | OS disk size in GB |
-
-## Integration
-
-Point an F5 XC origin pool at the VM's public IP. Configure HTTP load balancer
-with path-based routing to expose individual applications through XC.
+See the [Origin Server documentation](https://f5xc-salesdemos.github.io/origin-server/)
+for architecture, applications, terraform variables, and deployment details.

--- a/docs/traffic-generator.mdx
+++ b/docs/traffic-generator.mdx
@@ -1,63 +1,19 @@
 ---
 title: Traffic Generator
-description: Azure Ubuntu 24.04 VM with 50+ security testing tools and 17 traffic suites for generating WAF, API, bot, reconnaissance, SSL, and JavaScript exploit traffic.
+description: Azure VM generating attack traffic, reconnaissance, and bot simulation against F5 XC protected applications.
 ---
 
-The traffic generator is an Azure Ubuntu 24.04 VM (Standard_F16s_v2) pre-loaded
-with 50+ security testing tools and 17 traffic suites targeting 9 vulnerable
-applications on the origin server.
+The traffic generator is an Azure VM that produces attack traffic, reconnaissance
+scans, and bot simulation against F5 Distributed Cloud HTTP load balancers. It
+validates that WAF policies, Bot Defense, API Security, and Client-Side Defense
+are correctly configured.
 
-## Tool Categories
+## F5 XC Features Validated
 
-| Category | Tools | Purpose |
-|---|---|---|
-| Web Testing | Nikto, SQLMap, Gobuster, Nuclei, curl | Web application vulnerability scanning |
-| Network Analysis | Nmap, tcpdump, Wireshark CLI | Network reconnaissance and packet analysis |
-| MITM / Proxy | mitmproxy | Traffic interception and modification |
-| SSL/TLS | testssl.sh, sslscan | Certificate and cipher analysis |
-| Browser Automation | Playwright, Puppeteer | Headless browser-based attack simulation |
-| Credential Testing | Hydra | Brute-force authentication testing |
-| Load Testing | wrk, hey, vegeta | HTTP load generation and benchmarking |
-| Exploit Frameworks | ZAP, Metasploit (full tier only) | Advanced exploitation |
+- **Web Application Firewall** — SQL injection, XSS, command injection, path traversal payloads
+- **Bot Defense** — headless browser automation, credential stuffing, rapid crawling
+- **API Security** — OWASP API Top 10 attacks, GraphQL abuse, parameter fuzzing
+- **Client-Side Defense** — Magecart-style skimmer injection, DOM manipulation
 
-## Traffic Suites
-
-17 pre-built suites in `/opt/traffic-generator/suites/`:
-
-- `api-attacks` — OWASP API Top 10 against VAmPI
-- `bot-simulation` — Headless browser credential stuffing and scraping
-- `cdn-load-testing` — Cache behavior, throughput, and keepalive benchmarks
-- `crapi-exploits` — BOLA, OTP brute-force, mass assignment against crAPI
-- `csd-demo-attacks` — Magecart skimmer, formjacker, keylogger, cryptominer
-- `dvga-exploits` — GraphQL batch queries, recursion, injection against DVGA
-- `dvwa-exploits` — OWASP Top 10 chains against DVWA
-- `javascript-exploits` — Client-side injection and DOM manipulation
-- `juice-shop-exploits` — SQLi, XSS, IDOR against Juice Shop
-- `mitre-attack` — MITRE ATT&CK framework tactic mapping
-- `owasp-scanning` — ZAP, Nikto, Nuclei comprehensive scanning
-- `performance-testing` — Concurrency ramp, spike, endurance, breakpoint
-- `reconnaissance` — Nmap, Masscan, Gobuster enumeration
-- `restaurant-exploits` — OWASP API 2023 against RESTaurant
-- `ssl-scanning` — TLS configuration auditing
-- `traffic-generation` — Legitimate baseline traffic
-- `web-app-attacks` — SQLi, XSS, command injection, path traversal
-
-## Terraform Variables
-
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `subscription_id` | Yes | — | Azure subscription ID |
-| `target_fqdn` | Yes | — | F5 XC load balancer FQDN to target |
-| `deployer` | No | *(auto from Azure AD)* | Override for deployer identifier |
-| `location` | No | `eastus2` | Azure region |
-| `environment` | No | `lab` | Environment label for resource naming |
-| `vm_size` | No | `Standard_F16s_v2` | Azure VM size |
-| `disk_size_gb` | No | `64` | OS disk size in GB |
-| `target_origin_ip` | No | — | Direct origin IP for bypass testing |
-| `tool_tier` | No | `standard` | `standard` or `full` (includes Metasploit) |
-
-## Integration
-
-Deploy after the origin server and F5 XC load balancer are configured. Set
-`target_fqdn` to the XC load balancer FQDN. Use `runner.sh` to orchestrate
-attack suites.
+See the [Traffic Generator documentation](https://f5xc-salesdemos.github.io/traffic-generator/)
+for tool catalog, traffic suites, terraform variables, and deployment details.


### PR DESCRIPTION
## Summary

- Remove duplicated volatile facts (container counts, tool counts, suite counts, VM sizes, disk sizes) from marketplace docs pages
- Each component page now describes purpose and role only, with specifics owned by the component repos
- Replace the VM size table in `01-overview.mdx` with a cross-component integration story describing deployment order and architecture flow

Closes #14

## Test plan

- [ ] CI checks pass
- [ ] Docs site renders correctly after merge
- [ ] No broken links from content removal
- [ ] Component pages still convey purpose and role clearly