### PR TITLE
fix: remove volatile numbers from federated sites descriptions

### DIFF
--- a/docs/llms-federated-sites.json
+++ b/docs/llms-federated-sites.json
@@ -2,12 +2,12 @@
   {
     "label": "Origin Server",
     "url": "https://f5xc-salesdemos.github.io/origin-server/llms.txt",
-    "description": "Ubuntu 24.04 origin server with 9 vulnerable web applications for F5 XC demo environments"
+    "description": "Azure VM hosting vulnerable web applications for WAF, API security, bot defense, and client-side defense testing"
   },
   {
     "label": "Traffic Generator",
     "url": "https://f5xc-salesdemos.github.io/traffic-generator/llms.txt",
-    "description": "Azure Ubuntu 24.04 VM with 50+ security tools and attack suites for F5 XC demo traffic generation"
+    "description": "Azure VM generating attack traffic, reconnaissance, and bot simulation against F5 XC protected applications"
   },
   {
     "label": "CDN Simulator",


### PR DESCRIPTION
## Summary

- Remove volatile counts ("9 vulnerable web applications", "50+ security tools") from `docs/llms-federated-sites.json`
- Replace with purpose-only descriptions matching the DRY-thinned `index.mdx` LinkCard text
- CDN Simulator description was already clean and unchanged

Closes #19

## Test plan

- [ ] CI checks pass
- [ ] Verify `llms-federated-sites.json` contains no volatile numbers
- [ ] Verify federated sites descriptions match purpose-only format