### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -12,7 +12,9 @@
       ".github/workflows/super-linter.yml"
     ],
     "api-specs": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
-    "api-specs-enriched": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"]
+    "api-specs-enriched": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
+    "vscode-f5xc-tools": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
+    "i18n-core": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"]
   },
   "protected_files": [
     ".github/workflows/github-pages-deploy.yml",
@@ -51,6 +53,8 @@
     ".isort.cfg",
     ".python-lint",
     ".mypy.ini",
+    "scripts/locale-lint.sh",
+    "trivy.yaml",
     ".claude/settings.json",
     ".claude/governance.json",
     ".claude/hooks/protect-managed-files.sh"

--- a/.github/workflows/translation-audit.yml
+++ b/.github/workflows/translation-audit.yml
@@ -1,0 +1,18 @@
+---
+# Managed by docs-control. Verifies that translations stay fresh when
+# English docs change. Generation happens in pre-commit (docs-translate
+# --staged); this gate only audits sourceHash freshness (no API calls).
+name: Translation Audit
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    # Read-only freshness audit — no secrets required.
+    uses: f5xc-salesdemos/docs-control/.github/workflows/translation-audit.yml@main

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ projects/
 .claude/todos/
 .claude/worktrees/
 .claude/scheduled_tasks.lock
+.remember/
 .playwright-mcp/
 .serena/
 .auto-claude/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -184,6 +184,26 @@ repos:
         language: system
         pass_filenames: false
 
+  # ===========================================================================
+  # Translation generation — regenerate locale docs when English changes.
+  # Runs docs-translate --staged (docs-theme) for staged docs/en/*.mdx, which
+  # needs ANTHROPIC_API_KEY and the docs-theme toolchain. No-ops gracefully
+  # when either is unavailable; the required CI translation-audit verifies
+  # freshness regardless. Generation is intentionally local, never in CI.
+  # ===========================================================================
+  - repo: local
+    hooks:
+      - id: docs-translate
+        name: "i18n: regenerate translations for staged English docs"
+        entry: >-
+          bash -c
+          'if command -v docs-translate >/dev/null 2>&1 && [ -n "${ANTHROPIC_API_KEY:-}" ];
+          then docs-translate --staged;
+          else echo "[i18n] docs-translate/ANTHROPIC_API_KEY unavailable — skipping; CI translation-audit will verify freshness."; fi'
+        language: system
+        files: ^docs/en/.*\.mdx?$
+        pass_filenames: false
+
 ci:
   autofix_prs: true
   autoupdate_schedule: weekly
@@ -204,3 +224,4 @@ ci:
     - zizmor
     - checkov
     - gitleaks
+    - docs-translate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,5 +10,8 @@ A hook blocks direct edits — open an issue in docs-control instead.
 - The `main` branch is protected — never commit or push directly to it.
 - Create a feature branch, commit there, and open a pull request.
 - Every pull request must reference a GitHub issue (CI enforces this).
+- **Perform all git operations directly.** Do not delegate git commits,
+  pushes, or pull requests to subagents. Run `git`, `gh`, and CLI
+  commands yourself.
 
 See `CONTRIBUTING.md` for project rules.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,8 @@ If you are Claude Code, Copilot, or another AI coding assistant, follow these ru
 2. **Always work on a feature branch.** Never commit directly to `main`.
 3. **Always link the PR to the issue.** Use `Closes #N` in the PR description.
 4. **Use the `/ship` skill** when available — it handles the full Issue → Branch → PR flow.
-5. **Never force push** or attempt to bypass branch protection.
-6. **Fill out the PR template checklist** completely.
-7. **Follow the branch naming convention**: `feature/<issue>-desc`, `fix/<issue>-desc`, `docs/<issue>-desc`.
-8. **Respect CODEOWNERS** — Review the CODEOWNERS file for the default reviewer.
+5. **Perform git operations directly.** Run `git commit`, `git push`, and `gh pr create` yourself. Do not delegate to subagents.
+6. **Never force push** or attempt to bypass branch protection.
+7. **Fill out the PR template checklist** completely.
+8. **Follow the branch naming convention**: `feature/<issue>-desc`, `fix/<issue>-desc`, `docs/<issue>-desc`.
+9. **Respect CODEOWNERS** — Review the CODEOWNERS file for the default reviewer.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+🌐 English |
+[日本語](https://f5xc-salesdemos.github.io/demo-resources/ja/) |
+[한국어](https://f5xc-salesdemos.github.io/demo-resources/ko/) |
+[简体中文](https://f5xc-salesdemos.github.io/demo-resources/zh-cn/) |
+[繁體中文](https://f5xc-salesdemos.github.io/demo-resources/zh-tw/) |
+[Español](https://f5xc-salesdemos.github.io/demo-resources/es/) |
+[Português](https://f5xc-salesdemos.github.io/demo-resources/pt-br/) |
+[Français](https://f5xc-salesdemos.github.io/demo-resources/fr/) |
+[Deutsch](https://f5xc-salesdemos.github.io/demo-resources/de/) |
+[Italiano](https://f5xc-salesdemos.github.io/demo-resources/it/) |
+[العربية](https://f5xc-salesdemos.github.io/demo-resources/ar/) |
+[हिन्दी](https://f5xc-salesdemos.github.io/demo-resources/hi/) |
+[ไทย](https://f5xc-salesdemos.github.io/demo-resources/th/)
+
 # Demo Resources
 
 [![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/demo-resources/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/demo-resources/actions/workflows/github-pages-deploy.yml)

--- a/biome.json
+++ b/biome.json
@@ -26,7 +26,15 @@
   },
   "overrides": [
     {
-      "includes": ["dist/**", "build/**", "release/**", "vendor/**"],
+      "includes": [
+        "dist/**",
+        "build/**",
+        "release/**",
+        "vendor/**",
+        "docs/snapshots/**",
+        ".github/config/managed-files-manifest.json",
+        "**/*.svg"
+      ],
       "formatter": {
         "enabled": false
       },

--- a/scripts/locale-lint.sh
+++ b/scripts/locale-lint.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Detects hardcoded locale lists that should import from @f5xc-salesdemos/i18n-core.
+# Run from any repo root: bash scripts/locale-lint.sh
+# Exit 0 = clean, Exit 1 = violations found.
+set -euo pipefail
+
+VIOLATIONS=0
+
+# Patterns that indicate a hardcoded locale list rather than an i18n-core import
+PATTERNS=(
+  # Inline slug arrays containing 3+ locale codes (high confidence)
+  "'pt-br'.*'zh-cn'.*'zh-tw'"
+  '"pt-br".*"zh-cn".*"zh-tw"'
+  # Inline constant definitions that should come from i18n-core
+  'VALID_LOCALE_SLUGS\s*=\s*new\s+Set'
+  '(const|let|var|export)\s+LOCALE_DISPLAY_NAMES'
+  '(const|let|var|export)\s+LANG_TO_SLUG'
+  # Inline langToSlug function definition (not an import alias)
+  'function\s+langToSlug'
+)
+
+# Directories and files to exclude
+EXCLUDE_DIRS="node_modules|dist|\.git|coverage|\.astro|\.next|out|build"
+EXCLUDE_FILES="locale-lint\.sh|\.test\.|\.spec\."
+
+check_pattern() {
+  local pattern="$1"
+  local results
+  results=$(grep -rn --include='*.ts' --include='*.js' --include='*.tsx' --include='*.jsx' \
+    -E "$pattern" . 2>/dev/null |
+    grep -vE "($EXCLUDE_DIRS)" |
+    grep -vE "($EXCLUDE_FILES)" |
+    grep -vE "from\s+['\"]@f5xc-salesdemos/i18n-core" |
+    grep -vE "i18n-core/(src|dist)/" ||
+    true)
+
+  if [ -n "$results" ]; then
+    echo "$results"
+    return 1
+  fi
+  return 0
+}
+
+echo "Locale lint: checking for hardcoded locale lists..."
+echo ""
+
+for pattern in "${PATTERNS[@]}"; do
+  if ! check_pattern "$pattern"; then
+    VIOLATIONS=$((VIOLATIONS + 1))
+  fi
+done
+
+echo ""
+if [ "$VIOLATIONS" -gt 0 ]; then
+  echo "FAIL: Found $VIOLATIONS pattern(s) with hardcoded locale data."
+  echo "These should import from @f5xc-salesdemos/i18n-core instead."
+  exit 1
+else
+  echo "PASS: No hardcoded locale lists detected."
+  exit 0
+fi


### PR DESCRIPTION
Closes #159

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .github/workflows/translation-audit.yml
- CONTRIBUTING.md
- CLAUDE.md
- .gitignore
- .pre-commit-config.yaml
- biome.json
- scripts/locale-lint.sh
- .claude/governance.json
- README.md